### PR TITLE
Fix undefined names in Python code

### DIFF
--- a/flixy/flixy/Tools/get_parent.py
+++ b/flixy/flixy/Tools/get_parent.py
@@ -1,10 +1,11 @@
-def Get_parent(cls):
+def get_parent(cls):
 	return cls.parent
 
 def Get_first_parent (cls):
 	last_parent = get_parent(cls)
 	while last_parent != cls.page:
-		if get_parent(last_parent) == cls.page: break
+		if get_parent(last_parent) == cls.page:
+			break
 		last_parent = get_parent(last_parent)
 	
 	return last_parent

--- a/flixy/flixy/controls/TEXTVIEW.py
+++ b/flixy/flixy/controls/TEXTVIEW.py
@@ -49,7 +49,7 @@ class TextView (object):
 		tv.bg_color = self.bgcolor
 		tv.corner_radius = self.border_radius
 		if self.font_family == "default":
-			if self.page != None:
+			if self.page is not None:
 				tv.font = self.page.font_family, self.font_size
 		else:
 			tv.font = self.font_family, self.font_size
@@ -60,12 +60,12 @@ class TextView (object):
 		tv.alignment = self.text_align
 		
 		
-		if self.parent != None:
+		if self.parent is not None:
 			if self.expand_width:
 				self.__self_ui.width = self.parent.width
 				self.width = self.__self_ui.width
 			if self.expand_height:
-				if self.page.appbar == None or self.page != self.parent:
+				if self.page.appbar is None or self.page != self.parent:
 					self.__self_ui.height = self.parent.height
 					self.height = self.__self_ui.height
 				else:
@@ -109,7 +109,7 @@ class textViewDelegate (object):
 		do_action(self.self_class.on_start_edit, [self.self_class])
 	def textview_did_end_editing(self, textfield):
 		return True
-	def textview_should_return(self, textfield):
+	def textview_should_return(self, textview):
 		textview.end_editing()
 		do_action(self.self_class.on_done_edit, [self.self_class])
 		return True


### PR DESCRIPTION
Fix undefined names discovered at https://github.com/cclauss/flixy/actions

These issues can also be discovered by clicking `Analyze (pyflakes)` under Pythonista's `wrench` 🔧 icon.

<img width="319" alt="Screenshot 2023-04-10 at 07 40 05" src="https://user-images.githubusercontent.com/3709715/230834453-4a7a959e-c0ff-4c41-907c-3bdc7f99d4a5.png">

% `ruff --select=F821 --show-source .`
```
flixy/flixy/Tools/get_parent.py:5:16: F821 Undefined name `get_parent`
  |
5 | 	last_parent = get_parent(cls)
  |               ^^^^^^^^^^ F821
  |

flixy/flixy/Tools/get_parent.py:7:6: F821 Undefined name `get_parent`
  |
7 | 		if get_parent(last_parent) == cls.page: break
  |    ^^^^^^^^^^ F821
  |

flixy/flixy/Tools/get_parent.py:8:17: F821 Undefined name `get_parent`
  |
8 | 		last_parent = get_parent(last_parent)
  |               ^^^^^^^^^^ F821
  |

flixy/flixy/controls/TEXTVIEW.py:113:3: F821 Undefined name `textview`
    |
113 | 		textview.end_editing()
    | ^^^^^^^^ F821
    |

Found 4 errors.
```